### PR TITLE
zigdom.zig: remove `unused capture` which is incompatible with newer `zig` + fix compile instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 An example demonstrating Zig interacting with the DOM via JS.
 
-Compile with `zig build-lib -target wasm32-freestanding --release-small zigdom.zig`
+Compile with `zig build-lib zigdom.zig -target wasm32-freestanding -dynamic -OReleaseSmall`

--- a/zigdom.zig
+++ b/zigdom.zig
@@ -144,11 +144,15 @@ fn on_submit_event() void {
 }
 
 export fn launch_export() bool {
-    launch() catch |err| return false;
+    launch() catch {
+        return false;
+    };
     return true;
 }
 
 export fn _wasm_alloc(len: usize) u32 {
-    var buf = std.heap.page_allocator.alloc(u8, len) catch |err| return 0;
+    var buf = std.heap.page_allocator.alloc(u8, len) catch {
+        return 0;
+    };
     return @ptrToInt(buf.ptr);
 }


### PR DESCRIPTION
* zigdom.zig,compile: remove unused capture
* README: fix compile statement